### PR TITLE
Ported to Godot 3. json fixes, scene alignment fixes, etc.

### DIFF
--- a/addons/net.kivano.groups/Content/GroupInfoWin/AddMethodPopup/AddMethodPopup.tscn
+++ b/addons/net.kivano.groups/Content/GroupInfoWin/AddMethodPopup/AddMethodPopup.tscn
@@ -1,120 +1,170 @@
-[gd_scene load_steps=2 format=1]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://addons/net.kivano.groups/Content/GroupInfoWin/AddMethodPopup/AddMethodPopup.gd" type="Script" id=1]
 
-
 [node name="AddMethodPopup" type="WindowDialog"]
 
-anchor/left = 3
-anchor/top = 3
-anchor/right = 3
-anchor/bottom = 3
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 193.0
-margin/top = 75.0
-margin/right = -192.0
-margin/bottom = -62.0
-popup/exclusive = false
-window/title = "Define new group method"
-script/script = ExtResource( 1 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -1024.0
+margin_top = -600.0
+margin_right = -638.0
+margin_bottom = -447.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+popup_exclusive = false
+window_title = "Define new group method"
+resizable = false
+script = ExtResource( 1 )
+_sections_unfolded = [ "Anchor", "Margin", "Theme" ]
 
-[node name="methodName" type="TextEdit" parent="."]
+[node name="methodName" type="TextEdit" parent="." index="1"]
 
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 7.0
-margin/top = 15.0
-margin/right = 380.0
-margin/bottom = 44.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 7.0
+margin_top = 18.0
+margin_right = 380.0
+margin_bottom = 51.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+text = ""
+readonly = false
+highlight_current_line = false
+syntax_highlighting = false
 show_line_numbers = false
 highlight_all_occurrences = false
-caret/block_caret = false
-caret/caret_blink = false
-caret/caret_blink_speed = 0.65
+override_selected_font_color = false
+context_menu_enabled = true
+smooth_scrolling = false
+v_scroll_speed = 80.0
+hiding_enabled = 0
+caret_block_mode = false
+caret_blink = false
+caret_blink_speed = 0.65
+caret_moving_by_right_click = true
+_sections_unfolded = [ "Rect" ]
 
-[node name="methodParams" type="TextEdit" parent="."]
+[node name="methodParams" type="TextEdit" parent="." index="2"]
 
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 7.0
-margin/top = 59.0
-margin/right = 380.0
-margin/bottom = 96.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 7.0
+margin_top = 72.0
+margin_right = 380.0
+margin_bottom = 105.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+text = ""
+readonly = false
+highlight_current_line = false
+syntax_highlighting = false
 show_line_numbers = false
 highlight_all_occurrences = false
-caret/block_caret = false
-caret/caret_blink = false
-caret/caret_blink_speed = 0.65
+override_selected_font_color = false
+context_menu_enabled = true
+smooth_scrolling = false
+v_scroll_speed = 80.0
+hiding_enabled = 0
+caret_block_mode = false
+caret_blink = false
+caret_blink_speed = 0.65
+caret_moving_by_right_click = true
+_sections_unfolded = [ "Rect" ]
 
-[node name="titleMethodName" type="Label" parent="."]
+[node name="titleMethodName" type="Label" parent="." index="3"]
 
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 0.0
-margin/top = 3.0
-margin/right = 91.0
-margin/bottom = 17.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 2.0
+margin_top = -5.0
+margin_right = 101.0
+margin_bottom = 17.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
 text = "Method Name"
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="titleParams" type="Label" parent="."]
+[node name="titleParams" type="Label" parent="." index="4"]
 
-hint/tooltip = "Only number of paramaters will be taken into account during validation"
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 0.0
-margin/top = 44.0
-margin/right = 91.0
-margin/bottom = 58.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 2.0
+margin_top = 49.0
+margin_right = 233.0
+margin_bottom = 71.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
 text = "Parameters (separate with comma)"
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="SaveBtn" type="Button" parent="."]
+[node name="SaveBtn" type="Button" parent="." index="5"]
 
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 210.0
-margin/top = 100.0
-margin/right = 278.0
-margin/bottom = 132.0
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = 11.0
+margin_top = -37.0
+margin_right = 79.0
+margin_bottom = -5.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
+group = null
 text = "Save"
 flat = false
+align = 1
 
-[node name="cancelBtn" type="Button" parent="."]
+[node name="cancelBtn" type="Button" parent="." index="6"]
 
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 120.0
-margin/top = 100.0
-margin/right = 188.0
-margin/bottom = 132.0
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -78.0
+margin_top = -37.0
+margin_right = -10.0
+margin_bottom = -5.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
+group = null
 text = "Cancel"
 flat = false
+align = 1
 
 [connection signal="pressed" from="SaveBtn" to="." method="_on_SaveBtn_pressed"]
 

--- a/addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.gd
+++ b/addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.gd
@@ -33,11 +33,9 @@ var currentGroupID;
 func _notification(what):
 	if (what == NOTIFICATION_INSTANCED):
 		methodList = get_node("methodList");
-		get_node("description").set_readonly(true);
 	elif(what == NOTIFICATION_READY):
 		 groupManagerLogicRoot = get_node(path2GroupManagerRoot);
-		
-		
+
 ##################################################################################
 #########                       Getters and Setters                      #########
 ##################################################################################
@@ -46,7 +44,7 @@ func showGroup(inGroup, group2SceneValidationInfo):
 	#
 	currentGroupID = inGroup;
 	get_node("members").clear();
-	get_node("titleDesc").set_text("Group: " + currentGroupID);
+	get_node("titleDesc").set_text("Description of '%s':" % currentGroupID);
 	get_node("methodList").clear();
 	get_node("description").set_text("");
 	
@@ -67,9 +65,6 @@ func showGroup(inGroup, group2SceneValidationInfo):
 	popup();
 
 func addScene2SceneList(inGroup, inScene):
-	print("-------Adding scene to scene list-------");
-	print("scene name: ", inScene.filePath, " group: ", inGroup);
-	
 	var validationStatus = groupManagerLogicRoot.getValidationStatus4Scene(inGroup, inScene.filePath)
 	get_node("members").add_item(inScene.filePath);
 	var lastItemIdx =get_node("members").get_item_count() - 1;
@@ -95,9 +90,6 @@ func addScene2SceneList(inGroup, inScene):
 ##################################################################################
 #########                       Connected Signals                        #########
 ##################################################################################
-func _on_editDescriptionBtn_pressed():
-	get_node("description").set_readonly(false);
-
 func _on_addMethodBtn_pressed():
 	get_node("AddMethodPopup").popup();
 	

--- a/addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.tscn
+++ b/addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.tscn
@@ -1,199 +1,228 @@
-[gd_scene load_steps=3 format=1]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.gd" type="Script" id=1]
 [ext_resource path="res://addons/net.kivano.groups/Content/GroupInfoWin/AddMethodPopup/AddMethodPopup.tscn" type="PackedScene" id=2]
 
+[node name="GroupDesc" type="WindowDialog" index="0"]
 
-[node name="GroupDesc" type="WindowDialog"]
-
-anchor/left = 3
-anchor/top = 3
-anchor/right = 3
-anchor/bottom = 3
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 258.0
-margin/top = 268.0
-margin/right = -330.0
-margin/bottom = -288.0
-popup/exclusive = false
-window/title = "Group"
-script/script = ExtResource( 1 )
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 258.0
+margin_bottom = 496.0
+rect_min_size = Vector2( 258, 492 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+popup_exclusive = false
+window_title = "Group"
+resizable = false
+script = ExtResource( 1 )
+_sections_unfolded = [ "Rect", "Theme" ]
 path2GroupManagerRoot = NodePath("..")
 
-[node name="titleDesc" type="Label" parent="."]
+[node name="titleDesc" type="Label" parent="." index="1"]
 
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 1.0
-margin/top = 13.0
-margin/right = 67.0
-margin/bottom = 27.0
-text = "Description:"
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 7.0
+margin_right = 86.0
+margin_bottom = 29.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
+text = "Description of 'group':"
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
+_sections_unfolded = [ "Margin" ]
 
-[node name="description" type="TextEdit" parent="."]
+[node name="description" type="TextEdit" parent="." index="2"]
 
-anchor/right = 1
-hint/tooltip = "Describe what is purpose of this group here."
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 4.0
-margin/top = 30.0
-margin/right = 6.0
-margin/bottom = 155.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = 4.0
+margin_top = 34.0
+margin_right = -5.0
+margin_bottom = 154.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+text = ""
+readonly = false
+highlight_current_line = false
 syntax_highlighting = false
 show_line_numbers = false
 highlight_all_occurrences = false
-caret/block_caret = false
-caret/caret_blink = false
-caret/caret_blink_speed = 0.65
+override_selected_font_color = false
+context_menu_enabled = true
+smooth_scrolling = false
+v_scroll_speed = 80.0
+hiding_enabled = 0
+caret_block_mode = false
+caret_blink = false
+caret_blink_speed = 0.65
+caret_moving_by_right_click = true
+_sections_unfolded = [ "Margin", "Rect" ]
 
-[node name="titleMethods" type="Label" parent="."]
+[node name="titleMethods" type="Label" parent="." index="3"]
 
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 0.0
-margin/top = 163.0
-margin/right = 121.0
-margin/bottom = 177.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 161.0
+margin_right = 129.0
+margin_bottom = 183.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
 text = "Required Methods:"
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
+_sections_unfolded = [ "Margin" ]
 
-[node name="methodList" type="ItemList" parent="."]
+[node name="methodList" type="ItemList" parent="." index="4"]
 
-anchor/right = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 2.0
-margin/top = 180.0
-margin/right = 5.0
-margin/bottom = 293.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = 4.0
+margin_top = 188.0
+margin_right = -5.0
+margin_bottom = 308.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+items = [  ]
+select_mode = 0
+icon_mode = 1
+_sections_unfolded = [ "Hint", "Margin", "Rect" ]
 
-[node name="editDescriptionBtn" type="Button" parent="."]
+[node name="members" type="ItemList" parent="." index="5"]
 
-anchor/left = 1
-anchor/right = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 117.0
-margin/top = 10.0
-margin/right = 5.0
-margin/bottom = 30.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = 4.0
+margin_top = 338.0
+margin_right = -5.0
+margin_bottom = 462.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+items = [  ]
+select_mode = 0
+icon_mode = 1
+_sections_unfolded = [ "Hint", "Margin", "Rect" ]
+
+[node name="addMethodBtn" type="Button" parent="." index="6"]
+
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = -49.0
+margin_top = 159.0
+margin_right = -29.0
+margin_bottom = 181.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
-text = "Edit description"
-flat = false
-
-[node name="addMethodBtn" type="Button" parent="."]
-
-anchor/left = 1
-anchor/right = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 30.0
-margin/top = 160.0
-margin/right = 10.0
-margin/bottom = 180.0
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
+group = null
 text = "+"
 flat = false
+align = 1
+_sections_unfolded = [ "Rect" ]
 
-[node name="removeMethod" type="Button" parent="."]
+[node name="removeMethod" type="Button" parent="." index="7"]
 
-anchor/left = 1
-anchor/right = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 56.0
-margin/top = 160.0
-margin/right = 36.0
-margin/bottom = 180.0
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = -25.0
+margin_top = 159.0
+margin_right = -5.0
+margin_bottom = 181.0
+rect_min_size = Vector2( 20, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
+group = null
 text = "-"
 flat = false
+align = 1
+_sections_unfolded = [ "Rect" ]
 
-[node name="saveBtn" type="Button" parent="."]
+[node name="saveBtn" type="Button" parent="." index="8"]
 
-anchor/left = 1
-anchor/top = 1
-anchor/right = 1
-anchor/bottom = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 124.0
-margin/top = 248.0
-margin/right = 1.0
-margin/bottom = 219.0
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -108.0
+margin_top = -31.0
+margin_right = -10.0
+margin_bottom = -9.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
+group = null
 text = "Save Changes"
 flat = false
+align = 1
+_sections_unfolded = [ "Margin", "Rect" ]
 
-[node name="AddMethodPopup" parent="." instance=ExtResource( 2 )]
+[node name="AddMethodPopup" parent="." index="9" instance=ExtResource( 2 )]
 
-visibility/visible = false
+visible = false
 
-[node name="titleMembers" type="Label" parent="."]
+[node name="titleMembers" type="Label" parent="." index="10"]
 
-anchor/top = 1
-anchor/bottom = 1
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 1.0
-margin/top = 228.0
-margin/right = 122.0
-margin/bottom = 214.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 314.0
+margin_right = 121.0
+margin_bottom = 336.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
 text = "Member scenes:"
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
-
-[node name="members" type="ItemList" parent="."]
-
-anchor/top = 1
-anchor/right = 1
-anchor/bottom = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 3.0
-margin/top = 211.0
-margin/right = 4.0
-margin/bottom = 8.0
-
-[connection signal="pressed" from="editDescriptionBtn" to="." method="_on_editDescriptionBtn_pressed"]
 
 [connection signal="pressed" from="addMethodBtn" to="." method="_on_addMethodBtn_pressed"]
 

--- a/addons/net.kivano.groups/Content/GroupManagerWindow.gd
+++ b/addons/net.kivano.groups/Content/GroupManagerWindow.gd
@@ -16,7 +16,7 @@ extends Control
 ##################################################################################
 #####  Variables (Constants, Export Variables, Node Vars, Normal variables)  #####
 ######################### var myvar setget myvar_set,myvar_get ###################
-const PATH_2_PLUGIN_DATA_FILE = "res://addons/group_manager.dat";
+const PATH_2_PLUGIN_DATA_FILE = "res://addons/net.kivano.groups/group_manager.dat";
 
 const GROUP_STATUS_NOT_ADDED_2_MANAGER = 1;
 const GROUP_STATUS_NOT_VALIDATE = 2;
@@ -25,9 +25,9 @@ const GROUP_STATUS_VALIDATE = 3;
 const VALIDATION_STAT_4_SCENE_OK = 1;
 const VALIDATION_STAT_4_SCENE_ERROR = 2;
 
-const MSG_NOT_ADDED_2_MANAGER = "Group Manager don't know this group, double click to fill info";
-const MSG_SCN_NOT_VALIDATE = "Some scenes that are part of this group don't validate for required methods";
-const MSG_GROUP_OK = "No problem here";
+const MSG_NOT_ADDED_2_MANAGER = "Group Manager doesn't know this group, double click to fill info.";
+const MSG_SCN_NOT_VALIDATE = "Some scenes that are part of this group don't validate for required methods.";
+const MSG_GROUP_OK = "No problem here.";
 
 const ICO_OK      = preload("res://addons/net.kivano.groups/Content/assets/ok_ico.png");
 const ICO_ERROR   = preload("res://addons/net.kivano.groups/Content/assets/error_ico.png");
@@ -53,8 +53,7 @@ func _notification(what):
 		pass #only parts that are dependent on outside world (on theparents etc/also called when reparented) 
 
 func _enter_tree():
-	pass
-#	reset();
+	call_deferred("reset");
 
 func reset():
 	uiGroupList.clear()
@@ -83,11 +82,7 @@ func getGroupValidationStatus(inGroup):
 
 func getValidationStatus4Scene(inGroup, inSceneFilename):
 	var sceneValidationsList = group2SceneMap[inGroup];
-	print("sceneValidationsList:", sceneValidationsList)
 	for sceneValdationData in sceneValidationsList:
-		print(sceneValdationData.get_type());
-#		print(typeof(sceneValdationData))
-#		print(sceneValdationData.filepath)
 		if(sceneValdationData.getFilePath()==inSceneFilename):
 			if(sceneValdationData.notValidatingMethods.size()>0):
 				return VALIDATION_STAT_4_SCENE_ERROR;
@@ -193,11 +188,10 @@ func fetchAllSubfolders(inDirCursor, inOutSubfolderList, inOutScenesList):
 		if inDirCursor.current_is_dir():
 			if(currentFile!="..") && (currentFile!="."):
 				inOutSubfolderList.append(inDirCursor.get_current_dir()+"/"+currentFile);
-		elif((currentFile.extension()=="tscn") || (currentFile.extension()=="scn") || (currentFile.extension()=="xscn")):
+		elif((currentFile.get_extension()=="tscn") || (currentFile.get_extension()=="scn") || (currentFile.get_extension()=="xscn")):
 			var sceneFilePath = inDirCursor.get_current_dir()+"/"+currentFile;
 			sceneFilePath = sceneFilePath.replace("///", "//")
 			if(sceneFilePath!=null)&&(sceneFilePath!=""):
-#				print("adding scn: ", currentFile)
 				inOutScenesList.append(sceneFilePath);
 			
 		currentFile = inDirCursor.get_next();
@@ -236,8 +230,8 @@ func assignScenes2Group():
 
 func internalFillGroupList():
 	var groups = group2SceneMap.keys();
+	groups.sort()
 	for group in groups:
-		
 		uiGroupList.add_item(group);
 		var currentItemIdx = uiGroupList.get_item_count()-1;
 		var status =  getGroupValidationStatus(group);
@@ -255,7 +249,6 @@ func checkGroupStatus(inGroup, inSceneNode, inSceneFilename):
 	var validationinfo = findSceneValidationInfo(inGroup, inSceneFilename);
 	if(hasDescription4Group(inGroup)):
 		
-		#
 		var hasAllRequiredMethods = true;
 		var methods2Check = getOnlyGroupMethodNamesInList(inGroup)
 		
@@ -263,13 +256,8 @@ func checkGroupStatus(inGroup, inSceneNode, inSceneFilename):
 			if(!doSceneHaveMethod(inSceneNode, method)): 
 				validationinfo.addNotValidatingMethod(method);
 				hasAllRequiredMethods = false;
-#				get_node("debug").add_text(inSceneFilename + " dont have " + method + "\n")
-#			else: 
-#				get_node("debug").add_text(inSceneFilename + " have " + method + "\n")
-		#
 		if(hasAllRequiredMethods):
 			setGroupValidationStatus(inGroup, GROUP_STATUS_VALIDATE);
-#			get_node("debug").add_text(inGroup + " setting status validate " + "\n")
 		else:
 			setGroupValidationStatus(inGroup, GROUP_STATUS_NOT_VALIDATE);
 			
@@ -292,7 +280,7 @@ func doSceneHaveMethod(inScn, inMethod):
 func saveDict2File(inDict, inFilePath):
 	var saveGameFile = File.new();
 	saveGameFile.open(inFilePath, File.WRITE);
-	saveGameFile.store_line(inDict.to_json());
+	saveGameFile.store_line(to_json(inDict));
 	saveGameFile.close();
 
 func loadDictFromFile(inFilePath):
@@ -302,9 +290,7 @@ func loadDictFromFile(inFilePath):
 		return {};
 	
 	fileWithData.open(inFilePath, File.READ);
-	while (!fileWithData.eof_reached()):
-		var line = fileWithData.get_line();
-		loadedDictData.parse_json(line);
+	loadedDictData = parse_json(fileWithData.get_line());
 	fileWithData.close();
 	
 	return loadedDictData;

--- a/addons/net.kivano.groups/Content/GroupManagerWindow.tscn
+++ b/addons/net.kivano.groups/Content/GroupManagerWindow.tscn
@@ -1,85 +1,91 @@
-[gd_scene load_steps=3 format=1]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://addons/net.kivano.groups/Content/GroupManagerWindow.gd" type="Script" id=1]
-[ext_resource path="res://addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/net.kivano.groups/Content/assets/ok_ico.png" type="Texture" id=2]
+[ext_resource path="res://addons/net.kivano.groups/Content/GroupInfoWin/GroupInfoWin.tscn" type="PackedScene" id=3]
 
-[node name="Group Manager" type="Control"]
+[node name="Group Manager" type="Control" index="0"]
 
-anchor/right = 1
-anchor/bottom = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 0.0
-margin/top = 0.0
-margin/right = 0.0
-margin/bottom = 0.0
-script/script = ExtResource( 1 )
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+script = ExtResource( 1 )
 
-[node name="Title" type="Label" parent="."]
+[node name="Title" type="Label" parent="." index="0"]
 
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 2.0
-margin/top = 5.0
-margin/right = 114.0
-margin/bottom = 19.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 46.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 0, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
 text = "Groups"
+valign = 3
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
+_sections_unfolded = [ "Margin", "Rect" ]
 
-[node name="GroupList" type="ItemList" parent="."]
+[node name="GroupList" type="ItemList" parent="." index="1"]
 
-anchor/right = 1
-anchor/bottom = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 0.0
-margin/top = 20.0
-margin/right = 0.0
-margin/bottom = 0.0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = 30.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+items = [ "titterino", ExtResource( 2 ), false, "ass", ExtResource( 2 ), false ]
+select_mode = 0
+icon_mode = 1
 
-[node name="GroupDesc" parent="." instance=ExtResource( 2 )]
+[node name="GroupDesc" parent="." index="2" instance=ExtResource( 3 )]
 
-visibility/visible = false
+visible = false
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -688.0
+margin_top = -544.0
+margin_right = -430.0
+margin_bottom = -43.0
 
-[node name="RefreshBtn" type="Button" parent="."]
+[node name="RefreshBtn" type="Button" parent="." index="3"]
 
-anchor/left = 1
-anchor/right = 1
-focus/ignore_mouse = false
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 65.0
-margin/top = 3.0
-margin/right = 5.0
-margin/bottom = 23.0
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+margin_left = -62.0
+margin_right = -2.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 0, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
 toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
+group = null
 text = "Refresh"
 flat = false
-
-[node name="debug" type="RichTextLabel" parent="."]
-
-focus/ignore_mouse = true
-focus/stop_mouse = false
-size_flags/horizontal = 2
-size_flags/vertical = 2
-margin/left = 5.0
-margin/top = 65.0
-margin/right = 348.0
-margin/bottom = 240.0
-bbcode/enabled = true
-bbcode/bbcode = ""
-visible_characters = -1
+align = 1
+_sections_unfolded = [ "Margin", "Rect" ]
 
 [connection signal="item_activated" from="GroupList" to="." method="_on_GroupList_item_activated"]
 

--- a/addons/net.kivano.groups/GroupManagerInitScript.gd
+++ b/addons/net.kivano.groups/GroupManagerInitScript.gd
@@ -16,4 +16,4 @@ func _exit_tree():
     # Clean-up of the plugin goes here
     # Remove the scene from the docks:
     remove_control_from_docks( dock ) # Remove the dock
-    dock.free() # Erase the control from the memory
+    dock.queue_free() # Erase the control from the memory

--- a/addons/net.kivano.groups/GroupManagerInitScript.tscn
+++ b/addons/net.kivano.groups/GroupManagerInitScript.tscn
@@ -1,9 +1,0 @@
-[gd_scene load_steps=2 format=1]
-
-[ext_resource path="res://addons/net.kivano.groups/GroupManagerInitScript.gd" type="Script" id=1]
-
-[node name="EditorPlugin" type="EditorPlugin"]
-
-script/script = ExtResource( 1 )
-
-

--- a/addons/net.kivano.groups/plugin.cfg
+++ b/addons/net.kivano.groups/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="Group Manager"
-description="Plugin that allows you to scan your project in order to gather informations about groups"
+description="Plugin that allows you to scan your project in order to gather informations about groups."
 author="Jakub Grzesik"
 version="0.91"
 script="GroupManagerInitScript.gd"


### PR DESCRIPTION
Fixed the scene alignments to look proper and be usable again.
Fixed API changes (json, get_extension()).
Fixed some grammar ("Manager don't know" -> "Manager doesn't know", adding periods at the end of sentences, etc.)

I moved the group_manager.dat file inside the addon's directory, because I didn't want it to clutter up my otherwise unrelated `addons` directory. Didn't use any external paths because I want the group data to be included by the VCS.
Got rid of the "Edit Description" button in the group info window, because I'm not really sure what it was there for. There's no issue just letting people edit it as-is. On top of that, it was buggy (the description field didn't reset to read-only when the window was closed and re-opened).
Lastly, made it sort groups alphabetically, as previously they were in random order on every refresh.